### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@v5.0.0 # v4
         with:
           version: latest
 
@@ -28,7 +28,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@v5.0.4 # v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -59,12 +59,12 @@ jobs:
           fetch-depth: 0  # Required to push back to repo
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@v5.0.0 # v4
         with:
           version: latest
 
@@ -74,7 +74,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@v5.0.4 # v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v6.3.0 # v4
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: true
           fetch-depth: 0  # Required to push back to repo
@@ -104,7 +104,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: qoomon/actions--create-commit@dfef4d264de752be6d6195a4d61a2f3d3262d406
+      - uses: qoomon/actions--create-commit@v1.2.3
         with:
           message: "ci: update artifacts [skip ci]"
           skip-empty: true


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.